### PR TITLE
Fix API call descriptions resizing to a smaller width while showing or hiding

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -3,8 +3,7 @@
   <title>{{ site.title }}</title>
   <meta charset='utf-8'/>
   <meta name='description' content='Documentation website'/>
-  <meta name='viewport' content='width=device-width, initial-scale=1, maximum-scale=1'/>
-  <link href='http://fonts.googleapis.com/css?family=Open+Sans' rel='stylesheet' type='text/css'/>
+  <link href='https://fonts.googleapis.com/css?family=Open+Sans' rel='stylesheet' type='text/css'/>
   <link href='assets.css' rel='stylesheet' type='text/css'>
 </head>
 <body>  

--- a/assets.css
+++ b/assets.css
@@ -73,6 +73,7 @@ html {
 
 body {
     margin: 0;
+    min-width: 960px;
 }
 
 /* ==========================================================================
@@ -444,7 +445,7 @@ code {
   float: left;  
   height: 100%;
   overflow: auto;
-  position: fixed;
+  position: absolute;
   top: 0;
   width: 240px;
 }
@@ -617,9 +618,13 @@ code {
 }
 
 #content .body {
+  -moz-box-sizing: border-box;
+  -webkit-box-sizing: border-box;
   border-top: 1px solid #eef1f2;
+  box-sizing: border-box;
   display: block;
   padding: 15px 15px 0;
+  width: 100%;
 }
 
 #content .body code {


### PR DESCRIPTION
This commit provides a fix for a fairly visible bug.
While dropping down an API call description, the description is sized to a smaller width than it should be, and then abruptly resized to the correct width after the animation finishes.
Here's a slowed-down animation of the bug in action:

![preupdate](https://f.cloud.github.com/assets/3643764/2094493/dc71f3b8-8ecd-11e3-9752-ade89e6cf4c2.gif)

After a few minor changes to assets.css, the effect looks much more fluid:

![postupdate](https://f.cloud.github.com/assets/3643764/2094509/26aa7266-8ece-11e3-8dbb-4b5b631f11c4.gif)

I also made one or two smaller changes that many users should find helpful—index.html should now render nicely on smaller-screen devices (it was unnavigable before), and the Open Sans font is now loaded over https, so accessing an API description over https doesn't show any warnings.

(And on a non-pull-request-related-note— this is the best API documentation website that I've seen yet; thanks! :+1:)
